### PR TITLE
Integrate ESLint and resolve its warnings.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "airbnb"
+}

--- a/Nancy.ViewEngines.React.Example/Nancy.ViewEngines.React.Example.csproj
+++ b/Nancy.ViewEngines.React.Example/Nancy.ViewEngines.React.Example.csproj
@@ -167,11 +167,9 @@
     <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
   </Target>
   <Import Project="..\Nancy.ViewEngines.React\targets\Nancy.ViewEngines.React.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-       Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
+    <Exec Command=".\node_modules\.bin\eslint --ext .js,.jsx $(ProjectDir)\Views" WorkingDirectory="$(SolutionDir)" />
   </Target>
   <Target Name="AfterBuild">
   </Target>
-  -->
 </Project>

--- a/Nancy.ViewEngines.React.Example/Views/Console.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Console.jsx
@@ -3,15 +3,15 @@ import React from 'react';
 export default React.createClass({
   getInitialState() {
     return {
-      value: ''
+      value: '',
     };
   },
 
   render() {
     if (typeof document === 'undefined') {
       // output something only during server render
-      console.log('Log something during server render will be restored for client.')
-      console.warn('Warn and other console methods work fine too.');
+      console.log('Log something during server render will be restored for client.'); // eslint-disable-line no-console
+      console.warn('Warn and other console methods work fine too.'); // eslint-disable-line no-console
     }
 
     return (
@@ -25,6 +25,6 @@ export default React.createClass({
   handleChange(event) {
     const value = event.target.value;
     this.setState({ value });
-    console.log(value);
-  }
+    console.log(value); // eslint-disable-line no-console
+  },
 });

--- a/Nancy.ViewEngines.React.Example/Views/Form.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Form.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 
 export default React.createClass({
+  propTypes: {
+    text: React.PropTypes.string.isRequired,
+  },
+
   getInitialState() {
     return {
-      text: this.props.text
+      text: this.props.text,
     };
   },
 
@@ -35,5 +39,5 @@ export default React.createClass({
 
     xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
     xhr.send(`text=${this.state.text}`);
-  }
+  },
 });

--- a/Nancy.ViewEngines.React.Example/Views/Home.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Home.jsx
@@ -1,7 +1,11 @@
-﻿import React from 'react';
+import React from 'react';
 
 export default React.createClass({
+  propTypes: {
+    text: React.PropTypes.string.isRequired,
+  },
+
   render() {
     return <div>Home: <code>{this.props.text}</code></div>;
-  }
+  },
 });

--- a/Nancy.ViewEngines.React.Example/Views/Layout.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Layout.jsx
@@ -3,14 +3,14 @@ import React from 'react';
 export default React.createClass({
   propTypes: {
     view: React.PropTypes.func.isRequired, // React component constructor
-    model: React.PropTypes.object.isRequired
+    model: React.PropTypes.object.isRequired,
   },
 
   getInitialState() {
     return {
       title: this.props.model.title || 'Example Title',
-      styles: this.props.model.styles || []
-    }
+      styles: this.props.model.styles || [],
+    };
   },
 
   getTitle() {
@@ -34,6 +34,6 @@ export default React.createClass({
   },
 
   updateStyles(styles) {
-    this.setState({ styles })
-  }
+    this.setState({ styles });
+  },
 });

--- a/Nancy.ViewEngines.React.Example/Views/Style.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Style.jsx
@@ -1,11 +1,16 @@
 import React from 'react';
 
 export default React.createClass({
+  propTypes: {
+    styles: React.PropTypes.array.isRequired,
+    updateStyles: React.PropTypes.func.isRequired,
+  },
+
   getInitialState() {
     return {
       styles: this.props.styles,
-      value: 'red'
-    }
+      value: 'red',
+    };
   },
 
   renderItem(style) {
@@ -14,7 +19,7 @@ export default React.createClass({
 
     return (
       <li className={color} key={color}>
-        {style} <a href="javascript:void(0)" onClick={this.handleRemove(style)}>remove</a>
+        {style} <button onClick={this.handleRemove(style)}>remove</button>
       </li>
     );
   },
@@ -47,6 +52,6 @@ export default React.createClass({
       const styles = this.state.styles.filter(x => x !== style);
       this.props.updateStyles(styles);
       this.setState({ styles });
-    }
-  }
+    };
+  },
 });

--- a/Nancy.ViewEngines.React.Example/Views/Title.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Title.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
 
 export default React.createClass({
+  propTypes: {
+    title: React.PropTypes.string.isRequired,
+    updateTitle: React.PropTypes.func.isRequired,
+  },
+
   getInitialState() {
     return {
-      title: this.props.title
-    }
+      title: this.props.title,
+    };
   },
 
   render() {
@@ -23,5 +28,5 @@ export default React.createClass({
 
   handleUpdate() {
     this.props.updateTitle(this.state.title);
-  }
+  },
 });

--- a/Nancy.ViewEngines.React/Nancy.ViewEngines.React.csproj
+++ b/Nancy.ViewEngines.React/Nancy.ViewEngines.React.csproj
@@ -117,13 +117,14 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\packages\Npm.js.2.13.1.0\build\npm.js.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Npm.js.2.13.1.0\build\npm.js.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props'))" />
     <Error Condition="!Exists('..\packages\Vsxmd.1.0.0\build\Vsxmd.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Vsxmd.1.0.0\build\Vsxmd.targets'))" />
   </Target>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\packages\Npm.js.2.13.1.0\build\npm.js.targets" Condition="Exists('..\packages\Npm.js.2.13.1.0\build\npm.js.targets')" />
   <Target Name="BeforeBuild">
+    <Exec Command=".\packages\Npm.js.2.13.1.0\tools\npm --unicode=false install" WorkingDirectory="$(SolutionDir)" />
+    <Exec Command=".\node_modules\.bin\eslint --ext .js,.jsx $(ProjectDir)\tools" WorkingDirectory="$(SolutionDir)" />
+    <Exec Command="..\packages\Npm.js.2.13.1.0\tools\npm --unicode=false install" WorkingDirectory="$(MSBuildProjectPath)" />
     <Exec Command=".\tools\7za a -t7z -bd -mx9 -y .\node_modules.7z .\node_modules" WorkingDirectory="$(MSBuildProjectPath)" />
   </Target>
   <Target Name="AfterBuild">

--- a/Nancy.ViewEngines.React/tools/gulp/console.js
+++ b/Nancy.ViewEngines.React/tools/gulp/console.js
@@ -8,14 +8,14 @@ const logs = {};
 [
   'assert', 'clear', 'count', 'debug', 'dir', 'dirxml', 'exception', 'group',
   'groupCollapsed', 'groupEnd', 'markTimeline', 'profile', 'profileEnd',
-  'table', 'time', 'timeEnd', 'timeStamp'
+  'table', 'time', 'timeEnd', 'timeStamp',
 ].forEach(method => {
   logger[method] = logger[method] || () => {};
 });
 
 // restore the log arguements to redirect information for client
 [
-  'log', 'dir', 'trace', 'debug', 'info', 'warn', 'error'
+  'log', 'dir', 'trace', 'debug', 'info', 'warn', 'error',
 ].forEach(method => {
   logger[method] = logger[method] || ((...args) => {
     const stacktrace = (new Error()).stack;

--- a/Nancy.ViewEngines.React/tools/gulp/html.jsx
+++ b/Nancy.ViewEngines.React/tools/gulp/html.jsx
@@ -11,7 +11,7 @@ function getData(layout) {
 
 export default React.createClass({
   propTypes: {
-    layout: React.PropTypes.node.isRequired
+    layout: React.PropTypes.node.isRequired,
   },
 
   render() {
@@ -33,5 +33,5 @@ export default React.createClass({
         <body dangerouslySetInnerHTML={{__html: body}} />
       </html>
     );
-  }
+  },
 });

--- a/Nancy.ViewEngines.React/tools/gulp/layout.jsx
+++ b/Nancy.ViewEngines.React/tools/gulp/layout.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 export default React.createClass({
   propTypes: {
     view: React.PropTypes.func.isRequired, // React component constructor
-    model: React.PropTypes.object.isRequired
+    model: React.PropTypes.object.isRequired,
   },
 
   getTitle() {
@@ -16,5 +16,5 @@ export default React.createClass({
 
   render() {
     return <this.props.view {...this.props.model} />;
-  }
+  },
 });

--- a/Nancy.ViewEngines.React/tools/gulp/options.js
+++ b/Nancy.ViewEngines.React/tools/gulp/options.js
@@ -84,5 +84,5 @@ export default {
 
       options.publicPath = config.publicPath || 'assets';
     });
-  }
+  },
 };

--- a/Nancy.ViewEngines.React/tools/gulp/render.js
+++ b/Nancy.ViewEngines.React/tools/gulp/render.js
@@ -14,7 +14,8 @@ function hook(layout, callback) {
   const layoutRender = LayoutPrototype.render;
   LayoutPrototype.render = function _render() {
     const result = layoutRender.apply(this, arguments);
-    return callback(this, result);
+    callback(this);
+    return result;
   };
 }
 
@@ -39,12 +40,12 @@ function updateStyles(styles, currentStyles, head) {
 function renderClientSide(layout) {
   const instance = React.render(layout, window.document.body);
 
-  let head = document.getElementsByTagName('head')[0];
+  const head = document.getElementsByTagName('head')[0];
   let currentStyles = instance.getStyles();
   let currentTitle = instance.getTitle();
 
   // hooks to update static HTML elements when re-render layout
-  hook(layout, (instance, result) => {
+  hook(layout, () => {
     if (typeof instance.getTitle === 'function') {
       const title = instance.getTitle() || '';
       if (currentTitle !== title) {
@@ -58,8 +59,6 @@ function renderClientSide(layout) {
       updateStyles(styles, currentStyles, head);
       currentStyles = styles;
     }
-
-    return result;
   });
 }
 

--- a/Nancy.ViewEngines.React/tools/gulp/webpack.js
+++ b/Nancy.ViewEngines.React/tools/gulp/webpack.js
@@ -6,8 +6,8 @@ import webpack from 'webpack';
 export default (options) => {
   const uglifyPlugin = new webpack.optimize.UglifyJsPlugin({
     compress: {
-      warnings: false
-    }
+      warnings: false,
+    },
   });
 
   const compiler = webpack({
@@ -16,7 +16,7 @@ export default (options) => {
       path: options.clientPath,
       filename: options.scriptBundleName,
       publicPath: `/${options.assets}/`,
-      library: 'render' // expose as render method
+      library: 'render', // expose as render method
     },
     devtool: options.debug ? 'cheap-module-source-map' : null,
     plugins: options.debug ? null : [uglifyPlugin],
@@ -26,25 +26,24 @@ export default (options) => {
         {
           test: /\.jsx?$/,
           exclude: /node_modules/,
-          loader: 'babel'
+          loader: 'babel',
         },
         {
           test: /\.jsx?$/,
           loader: 'imports',
           query: {
-            // TODO console.log not work in browser
-            console: path.resolve(__dirname, './console.js')
-          }
-        }
-      ]
+            console: path.resolve(__dirname, './console.js'),
+          },
+        },
+      ],
     },
     resolve: {
       root: path.resolve(__dirname, '../../node_modules'),
-      extensions: ['', '.js', '.jsx']
+      extensions: ['', '.js', '.jsx'],
     },
     resolveLoader: {
-      root: path.resolve(__dirname, '../../node_modules')
-    }
+      root: path.resolve(__dirname, '../../node_modules'),
+    },
   });
 
   return new Promise((resolve, reject) => {
@@ -57,7 +56,7 @@ export default (options) => {
           colors: false,
           hash: false,
           version: false,
-          chunks: false
+          chunks: false,
         }));
       }
     });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "devDependencies": {
+    "babel-eslint": "^4.0.10",
+    "eslint": "^1.2.1",
+    "eslint-config-airbnb": "0.0.7",
+    "eslint-plugin-react": "^3.2.3"
+  }
+}


### PR DESCRIPTION
- Install ESLint as solution dependencies. But not impact React project package.
- Ingreate ESLint into projects, it break the build if ESLint not pass.
- Not use Npm.js targets, invoke the `npm install` manually.
- Resolve all ESLint warnings.
