### PR TITLE
Use view ID instead of view path in page.

### DIFF
--- a/Nancy.ViewEngines.React/Extension.cs
+++ b/Nancy.ViewEngines.React/Extension.cs
@@ -4,16 +4,17 @@
 
     internal static class Extension
     {
-        private const string ReactViewPath = "Nancy.ViewEngines.React.ViewPath";
+        private const string ReactViewId = "Nancy.ViewEngines.React.ViewId";
 
-        internal static void SetReactViewPath(this NancyContext context, string viewPath) =>
-            context.Items[ReactViewPath] = viewPath;
+        internal static void SetReactViewId(this NancyContext context, int viewId) =>
+            context.Items[ReactViewId] = viewId;
 
-        internal static string GetReactViewPath(this NancyContext context)
+        internal static int? GetReactViewId(this NancyContext context)
         {
-            object viewPath = null;
-            context.Items.TryGetValue(ReactViewPath, out viewPath);
-            return (string)viewPath;
+            object viewId = null;
+            return context.Items.TryGetValue(ReactViewId, out viewId)
+                ? (int?)viewId
+                : null;
         }
 
         internal static string GetResponseContent(this Response response)
@@ -33,12 +34,12 @@
         internal static string ResolvePath(params string[] paths) =>
             Path.GetFullPath(Path.Combine(paths));
 
-        internal static string InjectModel(this string content, string viewPath, object model) =>
+        internal static string InjectModel(this string content, int viewId, object model) =>
             !content.IsHtml() || !ReactConfiguration.Script.InjectionEnabled
             ? content
             : content
                 .Replace("</head>", $"<script src='{ReactConfiguration.Script.Request}?t={ReactConfiguration.Script.HashCode}'></script></head>")
-                .Replace("</body>", $"<script>render({ReactConfiguration.Serializer.Serialize(viewPath)}, {ReactConfiguration.Serializer.Serialize(model)})</script></body>");
+                .Replace("</body>", $"<script>render({viewId}, {ReactConfiguration.Serializer.Serialize(model)})</script></body>");
 
         internal static string NormalizeDocType(this string content) =>
             !content.StartsWith("<html>")

--- a/Nancy.ViewEngines.React/ReactPipeline.cs
+++ b/Nancy.ViewEngines.React/ReactPipeline.cs
@@ -23,17 +23,17 @@
             pipelines.AfterRequest += async context =>
             {
                 Response response = context.Response;
-                string viewPath = context.GetReactViewPath();
+                var viewId = context.GetReactViewId();
                 object model = context.NegotiationContext.DefaultModel;
 
                 // check if it is a React response
-                if (response != null && viewPath != null && model != null)
+                if (response != null && viewId != null && model != null)
                 {
                     // it is a need to pre-execute the response, otherwise throws NullReference
                     await response.PreExecute(context);
 
                     string injected = response.GetResponseContent()
-                        .InjectModel(viewPath, model)
+                        .InjectModel(viewId.Value, model)
                         .NormalizeDocType();
 
                     byte[] buffer = Encoding.UTF8.GetBytes(injected);

--- a/Nancy.ViewEngines.React/tools/gulpfile.js
+++ b/Nancy.ViewEngines.React/tools/gulpfile.js
@@ -33,7 +33,16 @@ gulp.task('index', ['init', 'clean'], function _index() {
     .pipe(gulp.dest(clientPath));
 });
 
-gulp.task('webpack', ['init', 'clean', 'index'], function _webpack() {
+gulp.task('index-mapping', ['init', 'index'], function _indexMapping(done) {
+  const path = require('path');
+  const fs = require('fs');
+  const pathMapping = require('./gulp/build-index').pathMapping;
+  const content = JSON.stringify(pathMapping, null, 4);
+  const filePath = path.resolve(options.clientPath, 'index.map');
+  fs.writeFile(filePath, content, done);
+});
+
+gulp.task('webpack', ['init', 'index', 'index-mapping'], function _webpack() {
   const webpack = require('./gulp/webpack');
   return webpack(options);
 });


### PR DESCRIPTION
- Use secret number as view ID instead of view path. Keep view path as a comment
- User will not get the directory hierarchy from the view path information any more.
- In release build, view path comment will be removed to avoid security issue.
