### PR TITLE
Refine configuration

### DIFF
--- a/Nancy.ViewEngines.React/Extension.cs
+++ b/Nancy.ViewEngines.React/Extension.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.IO;
+    using static ReactStatics;
 
     internal static class Extension
     {
@@ -50,6 +51,6 @@
             : "null";
 
         private static string AsJson(this object @object) =>
-            ReactConfiguration.Serializer.Serialize(@object);
+            Serializer.Serialize(@object);
     }
 }

--- a/Nancy.ViewEngines.React/Nancy.ViewEngines.React.csproj
+++ b/Nancy.ViewEngines.React/Nancy.ViewEngines.React.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReactConfiguration.cs" />
     <Compile Include="ReactConventions.cs" />
+    <Compile Include="ReactStatics.cs" />
     <Compile Include="ReactViewEngine.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Nancy.ViewEngines.React/ReactConfiguration.cs
+++ b/Nancy.ViewEngines.React/ReactConfiguration.cs
@@ -24,7 +24,6 @@
 
             // must be place at the end of configuration initialization
             Script = new BundleConfiguration("scriptBundleName", "script.js");
-            Style = new BundleConfiguration("styleBundleName", "style.css");
         }
 
         internal static string ClientPath { get; }
@@ -34,8 +33,6 @@
         internal static IEnumerable<string> Extensions { get; }
 
         internal static BundleConfiguration Script { get; }
-
-        internal static BundleConfiguration Style { get; }
 
         private static string GetAssemblyPath()
         {

--- a/Nancy.ViewEngines.React/ReactConfiguration.cs
+++ b/Nancy.ViewEngines.React/ReactConfiguration.cs
@@ -10,14 +10,11 @@
     {
         static ReactConfiguration()
         {
-            // e.g., C:/project/bin/
-            string assemblyPath = GetAssemblyPath();
-
             // e.g., /assets/
             PublicPath = string.Concat('/', GetSettingOrDefault("publicPath", "assets").Trim('/'), '/');
 
             // e.g., C:/project/bin/client/
-            ClientPath = Extension.ResolvePath(assemblyPath, GetSettingOrDefault("clientPath", "client"));
+            ClientPath = Extension.ResolvePath(AssemblyPath, GetSettingOrDefault("clientPath", "client"));
 
             // e.g., ['jsx']
             Extensions = GetSettingOrDefault("extensions", "jsx").Split(';').Select(x => x.TrimStart('.'));
@@ -34,17 +31,20 @@
 
         internal static BundleConfiguration Script { get; }
 
-        private static string GetAssemblyPath()
+        private static string AssemblyPath
         {
-            // e.g., file:///C:/project/bin/web.dll
-            string codeBase = typeof(ReactConfiguration).Assembly.CodeBase;
+            get
+            {
+                // e.g., file:///C:/project/bin/web.dll
+                string codeBase = typeof(ReactConfiguration).Assembly.CodeBase;
 
-            // e.g., C:/project/bin/web.dll
-            string assemblyFilePath = new Uri(codeBase).LocalPath;
+                // e.g., C:/project/bin/web.dll
+                string assemblyFilePath = new Uri(codeBase).LocalPath;
 
-            // e.g., C:/project/bin/
-            string assemblyPath = Path.GetDirectoryName(assemblyFilePath);
-            return assemblyPath;
+                // e.g., C:/project/bin/
+                string assemblyPath = Path.GetDirectoryName(assemblyFilePath);
+                return assemblyPath;
+            }
         }
 
         private static string GetSettingOrDefault(string key, string defaultValue)

--- a/Nancy.ViewEngines.React/ReactConfiguration.cs
+++ b/Nancy.ViewEngines.React/ReactConfiguration.cs
@@ -3,21 +3,13 @@
     using System;
     using System.Collections.Generic;
     using System.Configuration;
-    using System.Diagnostics;
     using System.IO;
     using System.Linq;
-    using System.Reflection;
-    using Json;
 
     internal static class ReactConfiguration
     {
         static ReactConfiguration()
         {
-            DebugMode = AppDomain.CurrentDomain.GetAssemblies().Any(AssemblyInDebugMode);
-
-            Serializer = new JavaScriptSerializer();
-            Serializer.RegisterConverters(JsonSettings.Converters, JsonSettings.PrimitiveConverters);
-
             // e.g., C:/project/bin/
             string assemblyPath = GetAssemblyPath();
 
@@ -35,8 +27,6 @@
             Style = new BundleConfiguration("styleBundleName", "style.css");
         }
 
-        internal static bool DebugMode { get; }
-
         internal static string ClientPath { get; }
 
         internal static string PublicPath { get; }
@@ -46,8 +36,6 @@
         internal static BundleConfiguration Script { get; }
 
         internal static BundleConfiguration Style { get; }
-
-        internal static JavaScriptSerializer Serializer { get; }
 
         private static string GetAssemblyPath()
         {
@@ -67,9 +55,6 @@
             string value = ConfigurationManager.AppSettings[key];
             return string.IsNullOrWhiteSpace(value) ? defaultValue : value;
         }
-
-        private static bool AssemblyInDebugMode(Assembly assembly) =>
-            assembly.GetCustomAttributes<DebuggableAttribute>().Any(x => x.IsJITTrackingEnabled);
 
         internal class BundleConfiguration
         {

--- a/Nancy.ViewEngines.React/ReactConventions.cs
+++ b/Nancy.ViewEngines.React/ReactConventions.cs
@@ -4,6 +4,7 @@
     using System.IO;
     using Conventions;
     using Responses;
+    using static ReactStatics;
 
     /// <inheritdoc/>
     public class ReactConventions : IConvention
@@ -27,7 +28,7 @@
                 string filePath = Extension.ResolvePath(ReactConfiguration.ClientPath, relativePath);
 
                 // only serve bundle source mapping in debug mode
-                return !ReactConfiguration.DebugMode && Path.GetExtension(filePath) == ".map"
+                return !DebugMode && Path.GetExtension(filePath) == ".map"
                     ? null
                     : new GenericFileResponse(filePath);
             }

--- a/Nancy.ViewEngines.React/ReactStatics.cs
+++ b/Nancy.ViewEngines.React/ReactStatics.cs
@@ -1,0 +1,26 @@
+﻿namespace Nancy.ViewEngines.React
+{
+    using System;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Reflection;
+    using Json;
+
+    internal static class ReactStatics
+    {
+        static ReactStatics()
+        {
+            DebugMode = AppDomain.CurrentDomain.GetAssemblies().Any(AssemblyInDebugMode);
+
+            Serializer = new JavaScriptSerializer();
+            Serializer.RegisterConverters(JsonSettings.Converters, JsonSettings.PrimitiveConverters);
+        }
+
+        internal static bool DebugMode { get; }
+
+        internal static JavaScriptSerializer Serializer { get; }
+
+        private static bool AssemblyInDebugMode(Assembly assembly) =>
+            assembly.GetCustomAttributes<DebuggableAttribute>().Any(x => x.IsJITTrackingEnabled);
+    }
+}

--- a/Nancy.ViewEngines.React/ReactViewEngine.cs
+++ b/Nancy.ViewEngines.React/ReactViewEngine.cs
@@ -5,6 +5,7 @@
     using System.IO;
     using JSPool;
     using Responses;
+    using static ReactStatics;
 
     /// <summary>
     /// The React.js view engine.
@@ -19,7 +20,7 @@
         {
             var path = Extension.ResolvePath(ReactConfiguration.ClientPath, "path.map");
             var content = File.ReadAllText(path);
-            pathMapping = ReactConfiguration.Serializer.Deserialize<Dictionary<string, int>>(content);
+            pathMapping = Serializer.Deserialize<Dictionary<string, int>>(content);
         }
 
         /// <summary>
@@ -69,8 +70,8 @@
                 try
                 {
                     var viewId = GetViewId(viewLocationResult);
-                    var payload = ReactConfiguration.Serializer.Serialize(modelObject);
-                    var csrfJson = ReactConfiguration.Serializer.Serialize(csrfToken);
+                    var payload = Serializer.Serialize(modelObject);
+                    var csrfJson = Serializer.Serialize(csrfToken);
 
                     var html = engine.CallFunction<string>("render", viewId, payload, csrfJson)
                         .InjectModel(viewId, modelObject, csrfToken)

--- a/Nancy.ViewEngines.React/tools/gulp/entry.js
+++ b/Nancy.ViewEngines.React/tools/gulp/entry.js
@@ -12,15 +12,13 @@ const XPATH_SELECTOR = '//proj:Content/@Include | //proj:None/@Include';
 let pathMappingCount = 0;
 const pathMapping = {};
 
-function requireLibrary(libirary, indent = 0) {
+function requireLibrary(libirary) {
   const libiraryPath = libirary[0] === '.'
     ? path.resolve(__dirname, libirary)
     : libirary;
 
-  const indention = Array(indent + 1).join(' ');
   const libiraryPathString = JSON.stringify(libiraryPath);
-
-  return `${indention}require(${libiraryPathString})`;
+  return `require(${libiraryPathString})`;
 }
 
 function requireView(view) {
@@ -42,17 +40,12 @@ function buildEntryCode(items) {
     .filter(file => options.extensions.indexOf(path.extname(file)) !== -1)
     .map(file => [file.replace(/\\/g, '/'), requireView(file)]);
 
-  const clientCode = options.clientLibraries.map(x => requireLibrary(x, 2)).join(';\n');
-  const ifClientCode = options.clientLibraries.length === 0
-    ? ''
-    : `if (typeof window !== "undefined") {\n${clientCode};\n}\n\n`;
-
   const requireRender = requireLibrary('../client/render.js');
   const lookupCode = lookup.map(formatLine).join(',\n');
   const requireLayout = requireView(options.layout);
   const renderCode = `module.exports = ${requireRender}({\n${lookupCode}\n}, ${requireLayout});`;
 
-  return `${ifClientCode}${renderCode}`;
+  return renderCode;
 }
 
 function buildEntryFile(file) {

--- a/Nancy.ViewEngines.React/tools/gulp/options.js
+++ b/Nancy.ViewEngines.React/tools/gulp/options.js
@@ -76,7 +76,6 @@ export default {
       options.webpackLockPath = path.resolve(clientPath, 'webpack.lock');
 
       options.extensions = parseList(config.extensions, ['jsx']).map(x => `.${x.trim('.')}`);
-      options.clientLibraries = parseList(config.clientLibraries, []);
       options.layout = config.layout || path.resolve(__dirname, '../client/layout.jsx');
       options.scriptBundleName = config.scriptBundleName || 'script.js';
 


### PR DESCRIPTION
- Move the non-configurable static fields to ReactStatics static class.
- Remove Style bundle configuration, which is useless anymore.
- Rename GetAssemblyPath to AssemblyPath and make it as a property.
- Remove clientLibraries options. User can use customized layout to do the same thing.
