### PR TITLE
Update babel to 6.x

### DIFF
--- a/Nancy.ViewEngines.React/package.json
+++ b/Nancy.ViewEngines.React/package.json
@@ -1,8 +1,10 @@
 {
   "devDependencies": {
-    "babel": "^5.5.6",
-    "babel-core": "^5.8.14",
-    "babel-loader": "^5.3.2",
+    "babel-core": "^6.7.7",
+    "babel-loader": "^6.2.4",
+    "babel-polyfill": "^6.7.4",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
     "imports-loader": "^0.6.4",
     "mkdirp": "^0.5.1",
     "react": "^15.0.2",

--- a/Nancy.ViewEngines.React/tools/client/console.js
+++ b/Nancy.ViewEngines.React/tools/client/console.js
@@ -50,4 +50,4 @@ if (inServer) {
   logger.restore = () => logs.map(formatCode).join('');
 }
 
-export default logger; // as console
+module.exports = logger; // as console

--- a/Nancy.ViewEngines.React/tools/commands/entry.js
+++ b/Nancy.ViewEngines.React/tools/commands/entry.js
@@ -10,16 +10,13 @@ const writeFileWithDir = require('./file').writeFileWithDir;
 const PROJ_NAMESPACE = 'http://schemas.microsoft.com/developer/msbuild/2003';
 const XPATH_SELECTOR = '//proj:Content/@Include | //proj:None/@Include';
 
-const requirePolyfill = 'require("babel/polyfill")\n';
-
-
 function requireLibrary(libirary) {
   const libiraryPath = libirary[0] === '.'
     ? path.resolve(__dirname, libirary)
     : libirary;
 
   const libiraryPathString = JSON.stringify(libiraryPath);
-  return `require(${libiraryPathString})`;
+  return `require(${libiraryPathString}).default`;
 }
 
 function requireView(view, options) {
@@ -46,8 +43,7 @@ function buildEntryCode(items, options) {
   const requireRender = requireLibrary('../client/render.js');
   const lookupCode = lookup.map(formatLine).join(',\n');
   const requireLayout = requireView(options.layout, options);
-  const renderCode = `${requirePolyfill}\
-    module.exports = ${requireRender}({\n${lookupCode}\n}, ${requireLayout});`;
+  const renderCode = `module.exports = ${requireRender}({\n${lookupCode}\n}, ${requireLayout});`;
 
   return renderCode;
 }

--- a/Nancy.ViewEngines.React/tools/commands/webpack.js
+++ b/Nancy.ViewEngines.React/tools/commands/webpack.js
@@ -3,6 +3,10 @@
 const path = require('path');
 const webpack = require('webpack');
 
+function mapLocal(array) {
+  return array.map((item) => path.resolve(__dirname, '../../node_modules', item));
+}
+
 // TODO find a way to do webpack watch
 function compile(options) {
   const deinfePlugin = new webpack.DefinePlugin({
@@ -16,7 +20,10 @@ function compile(options) {
   });
 
   const compiler = webpack({
-    entry: options.entryFile,
+    entry: [
+      'babel-polyfill',
+      options.entryFile,
+    ],
     output: {
       path: options.clientPath,
       filename: options.scriptBundleName,
@@ -32,6 +39,12 @@ function compile(options) {
           test: /\.jsx?$/,
           exclude: /node_modules/,
           loader: 'babel',
+          query: {
+            presets: mapLocal([
+              'babel-preset-es2015',
+              'babel-preset-react',
+            ]),
+          },
         },
         {
           test: /\.jsx?$/,


### PR DESCRIPTION
- Install es2015 and react preset.
- Move babel-polyfill as entry point.
- Reference ES6 exports with `.default` in require.
- Fix the breaking reference in console.log file.
- Reference ES6 exports with `.default` in require.
