### PR TITLE
Convert React components to ES6 class

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -2,6 +2,8 @@
 extends:
   - airbnb
 
+parser: babel-eslint
+
 # Suppress lots of rules, treat as warnings. Revisit them later.
 rules:
   import/no-unresolved:

--- a/Nancy.ViewEngines.React.Example/.babelrc
+++ b/Nancy.ViewEngines.React.Example/.babelrc
@@ -2,5 +2,8 @@
   "presets": [
     "es2015",
     "react"
+  ],
+  "plugins": [
+    "transform-class-properties"
   ]
 }

--- a/Nancy.ViewEngines.React.Example/Views/Console.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Console.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 
 export default class Console extends React.Component {
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+
+    this.state = {
       value: '',
     };
   }
 
-  handleChange(event) {
+  handleChange = (event) => {
     const value = event.target.value;
     this.setState({ value });
     console.log(value); // eslint-disable-line no-console

--- a/Nancy.ViewEngines.React.Example/Views/Console.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Console.jsx
@@ -1,17 +1,17 @@
 import React from 'react';
 
-export default React.createClass({
+export default class Console extends React.Component {
   getInitialState() {
     return {
       value: '',
     };
-  },
+  }
 
   handleChange(event) {
     const value = event.target.value;
     this.setState({ value });
     console.log(value); // eslint-disable-line no-console
-  },
+  }
 
   render() {
     if (typeof document === 'undefined') {
@@ -34,5 +34,5 @@ export default React.createClass({
         <input type="text" value={this.state.value} onChange={this.handleChange} />
       </div>
     );
-  },
-});
+  }
+}

--- a/Nancy.ViewEngines.React.Example/Views/Form.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Form.jsx
@@ -1,20 +1,20 @@
 import React from 'react';
 
-export default React.createClass({
-  propTypes: {
+export default class Form extends React.Component {
+  static propTypes = {
     text: React.PropTypes.string,
-  },
+  }
 
   getInitialState() {
     return {
       text: this.props.text,
     };
-  },
+  }
 
   handleChange(event) {
     const text = event.target.value;
     this.setState({ text });
-  },
+  }
 
   handleSubmit(event) {
     event.preventDefault();
@@ -30,7 +30,7 @@ export default React.createClass({
 
     xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
     xhr.send(`text=${this.state.text}`);
-  },
+  }
 
   render() {
     return (
@@ -39,5 +39,5 @@ export default React.createClass({
         <input type="submit" value="Submit" />
       </form>
     );
-  },
-});
+  }
+}

--- a/Nancy.ViewEngines.React.Example/Views/Form.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Form.jsx
@@ -5,18 +5,20 @@ export default class Form extends React.Component {
     text: React.PropTypes.string,
   }
 
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+
+    this.state = {
       text: this.props.text,
     };
   }
 
-  handleChange(event) {
+  handleChange = (event) => {
     const text = event.target.value;
     this.setState({ text });
   }
 
-  handleSubmit(event) {
+  handleSubmit = (event) => {
     event.preventDefault();
 
     const xhr = new XMLHttpRequest();

--- a/Nancy.ViewEngines.React.Example/Views/Moment.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Moment.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import moment from 'moment';
 
 export default class Moment extends React.Component {
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+
+    this.state = {
       currentTime: null,
     };
   }
@@ -13,7 +15,7 @@ export default class Moment extends React.Component {
     setInterval(this.updateCurrentTime, 1000);
   }
 
-  updateCurrentTime() {
+  updateCurrentTime = () => {
     this.setState({
       currentTime: moment().format(),
     });

--- a/Nancy.ViewEngines.React.Example/Views/Moment.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Moment.jsx
@@ -1,25 +1,25 @@
 import React from 'react';
 import moment from 'moment';
 
-export default React.createClass({
+export default class Moment extends React.Component {
   getInitialState() {
     return {
       currentTime: null,
     };
-  },
+  }
 
   componentDidMount() {
     this.updateCurrentTime();
     setInterval(this.updateCurrentTime, 1000);
-  },
+  }
 
   updateCurrentTime() {
     this.setState({
       currentTime: moment().format(),
     });
-  },
+  }
 
   render() {
     return <div>Current time: <code>{this.state.currentTime}</code></div>;
-  },
-});
+  }
+}

--- a/Nancy.ViewEngines.React.Example/Views/Style.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Style.jsx
@@ -9,34 +9,33 @@ export default class Style extends React.Component {
     updateStyles: React.PropTypes.func.isRequired,
   }
 
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+
+    this.state = {
       styles: this.props.styles,
       value: 'red',
     };
   }
 
-  handleChange(event) {
-    const value = event.target.value;
-    this.setState({ value });
+  handleChange = (event) => {
+    this.setState({ value: event.target.value });
   }
 
-  handleAdd() {
+  handleAdd = () => {
     const value = '';
     const styles = this.state.styles.concat([`/style/color/${this.state.value}`]);
     this.props.updateStyles(styles);
     this.setState({ styles, value });
   }
 
-  handleRemove(style) {
-    return () => {
-      const styles = this.state.styles.filter(x => x !== style);
-      this.props.updateStyles(styles);
-      this.setState({ styles });
-    };
+  handleRemove = (style) => () => {
+    const styles = this.state.styles.filter(x => x !== style);
+    this.props.updateStyles(styles);
+    this.setState({ styles });
   }
 
-  renderItem(style) {
+  renderItem = (style) => {
     const segments = style.split('/');
     const color = segments[segments.length - 1];
 

--- a/Nancy.ViewEngines.React.Example/Views/Style.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Style.jsx
@@ -1,34 +1,32 @@
 import React from 'react';
 import Layout from './StyleLayout';
 
-export default React.createClass({
-  propTypes: {
+export default class Style extends React.Component {
+  static layout = Layout
+
+  static propTypes = {
     styles: React.PropTypes.array.isRequired,
     updateStyles: React.PropTypes.func.isRequired,
-  },
-
-  statics: {
-    layout: Layout,
-  },
+  }
 
   getInitialState() {
     return {
       styles: this.props.styles,
       value: 'red',
     };
-  },
+  }
 
   handleChange(event) {
     const value = event.target.value;
     this.setState({ value });
-  },
+  }
 
   handleAdd() {
     const value = '';
     const styles = this.state.styles.concat([`/style/color/${this.state.value}`]);
     this.props.updateStyles(styles);
     this.setState({ styles, value });
-  },
+  }
 
   handleRemove(style) {
     return () => {
@@ -36,7 +34,7 @@ export default React.createClass({
       this.props.updateStyles(styles);
       this.setState({ styles });
     };
-  },
+  }
 
   renderItem(style) {
     const segments = style.split('/');
@@ -47,7 +45,7 @@ export default React.createClass({
         {style} <button onClick={this.handleRemove(style)}>remove</button>
       </li>
     );
-  },
+  }
 
   render() {
     return (
@@ -58,5 +56,5 @@ export default React.createClass({
         <input type="button" value="Add" onClick={this.handleAdd} />
       </div>
     );
-  },
-});
+  }
+}

--- a/Nancy.ViewEngines.React.Example/Views/StyleLayout.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/StyleLayout.jsx
@@ -1,28 +1,28 @@
 import React from 'react';
 
-export default React.createClass({
-  propTypes: {
+export default class StyleLatyout extends React.Component {
+  static propTypes = {
     view: React.PropTypes.func.isRequired,
     model: React.PropTypes.object.isRequired,
-  },
+  }
 
   getInitialState() {
     return {
       styles: this.props.model.styles,
     };
-  },
+  }
 
   getStyles() {
     return this.state.styles;
-  },
+  }
 
   updateStyles(styles) {
     this.setState({ styles });
-  },
+  }
 
   render() {
     return (
       <this.props.view {...this.props.model} updateStyles={this.updateStyles} />
     );
-  },
-});
+  }
+}

--- a/Nancy.ViewEngines.React.Example/Views/StyleLayout.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/StyleLayout.jsx
@@ -6,17 +6,17 @@ export default class StyleLatyout extends React.Component {
     model: React.PropTypes.object.isRequired,
   }
 
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+
+    this.state = {
       styles: this.props.model.styles,
     };
   }
 
-  getStyles() {
-    return this.state.styles;
-  }
+  getStyles = () => this.state.styles
 
-  updateStyles(styles) {
+  updateStyles = (styles) => {
     this.setState({ styles });
   }
 

--- a/Nancy.ViewEngines.React.Example/Views/Title.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Title.jsx
@@ -1,30 +1,28 @@
 import React from 'react';
 import Layout from './TitleLayout';
 
-export default React.createClass({
-  propTypes: {
+export default class Title extends React.Component {
+  static layout = Layout
+
+  static propTypes = {
     title: React.PropTypes.string.isRequired,
     updateTitle: React.PropTypes.func.isRequired,
-  },
-
-  statics: {
-    layout: Layout,
-  },
+  }
 
   getInitialState() {
     return {
       title: this.props.title,
     };
-  },
+  }
 
   handleChange(event) {
     const title = event.target.value;
     this.setState({ title });
-  },
+  }
 
   handleUpdate() {
     this.props.updateTitle(this.state.title);
-  },
+  }
 
   render() {
     return (
@@ -38,5 +36,5 @@ export default React.createClass({
         <input type="button" value="Update" onClick={this.handleUpdate} />
       </div>
     );
-  },
-});
+  }
+}

--- a/Nancy.ViewEngines.React.Example/Views/Title.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/Title.jsx
@@ -9,18 +9,20 @@ export default class Title extends React.Component {
     updateTitle: React.PropTypes.func.isRequired,
   }
 
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+
+    this.state = {
       title: this.props.title,
     };
   }
 
-  handleChange(event) {
+  handleChange = (event) => {
     const title = event.target.value;
     this.setState({ title });
   }
 
-  handleUpdate() {
+  handleUpdate = () => {
     this.props.updateTitle(this.state.title);
   }
 

--- a/Nancy.ViewEngines.React.Example/Views/TitleLayout.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/TitleLayout.jsx
@@ -1,28 +1,28 @@
 import React from 'react';
 
-export default React.createClass({
-  propTypes: {
+export default class TitleLayout extends React.Component {
+  static propTypes = {
     view: React.PropTypes.func.isRequired,
     model: React.PropTypes.object.isRequired,
-  },
+  }
 
   getInitialState() {
     return {
       title: this.props.model.title,
     };
-  },
+  }
 
   getTitle() {
     return this.state.title;
-  },
+  }
 
   updateTitle(title) {
     this.setState({ title });
-  },
+  }
 
   render() {
     return (
       <this.props.view {...this.props.model} updateTitle={this.updateTitle} />
     );
-  },
-});
+  }
+}

--- a/Nancy.ViewEngines.React.Example/Views/TitleLayout.jsx
+++ b/Nancy.ViewEngines.React.Example/Views/TitleLayout.jsx
@@ -6,17 +6,17 @@ export default class TitleLayout extends React.Component {
     model: React.PropTypes.object.isRequired,
   }
 
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+
+    this.state = {
       title: this.props.model.title,
     };
   }
 
-  getTitle() {
-    return this.state.title;
-  }
+  getTitle = () => this.state.title
 
-  updateTitle(title) {
+  updateTitle = (title) => {
     this.setState({ title });
   }
 

--- a/Nancy.ViewEngines.React.Example/package.json
+++ b/Nancy.ViewEngines.React.Example/package.json
@@ -3,6 +3,7 @@
     "moment": "^2.13.0"
   },
   "devDependencies": {
+    "babel-plugin-transform-class-properties": "^6.6.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "babel-eslint": "^6.0.4",
     "eslint": "^2.9.0",
     "eslint-config-airbnb": "^8.0.0",
     "eslint-plugin-import": "^1.6.1",


### PR DESCRIPTION
- Install class-properties babel plugin, and enforce by ESLint rules.
- Leverage class properties for class static members.
- Resolve `this` keyword issue in React ES6 class components.
