### PR TITLE
Refine the build scripts

### DIFF
--- a/Nancy.ViewEngines.React.Example/Nancy.ViewEngines.React.Example.csproj
+++ b/Nancy.ViewEngines.React.Example/Nancy.ViewEngines.React.Example.csproj
@@ -178,7 +178,6 @@
   </Target>
   <Import Project="..\Nancy.ViewEngines.React\targets\Nancy.ViewEngines.React.targets" />
   <Target Name="BeforeBuild">
-    <Exec Command=".\node_modules\.bin\eslint --ext .js,.jsx &quot;$(ProjectDir)\Views&quot;" WorkingDirectory="$(SolutionDir)" />
   </Target>
   <Target Name="AfterBuild">
   </Target>

--- a/Nancy.ViewEngines.React.UnitTests/Test-JavaScript.ps1
+++ b/Nancy.ViewEngines.React.UnitTests/Test-JavaScript.ps1
@@ -1,8 +1,16 @@
 $Project = "$($env:APPVEYOR_BUILD_FOLDER)\Nancy.ViewEngines.React.UnitTests"
 $Stream = cmd /c "$($Project)\node_modules\.bin\mocha" --compilers js:babel/register -R json "$($Project)/*Tests/**/*.js"
-$Output = [String]::Join("", $Stream)
+if ($LastExitCode -ne 0) {
+    Write-Host "Fail the build because mocha command exits with $LastExitCode"
+    $host.SetShouldExit($LastExitCode)
+}
 
+$Output = [String]::Join("", $Stream)
 $Result = ConvertFrom-Json $Output
+if ($LastExitCode -ne 0) {
+    Write-Host "Fail the build because mocha report cannot convert to JSON. Actual value = $Output"
+    $host.SetShouldExit($LastExitCode)
+}
 
 $Failure = $false
 foreach ($Test in $Result.Tests) {
@@ -19,6 +27,6 @@ foreach ($Test in $Result.Tests) {
 }
 
 if ($Failure -eq $true) {
-    Write-Host "Failing build as there are broken tests"
+    Write-Host "Fail the build because there are failing test cases"
     $host.SetShouldExit(1)
 }

--- a/Nancy.ViewEngines.React.UnitTests/Test-JavaScript.ps1
+++ b/Nancy.ViewEngines.React.UnitTests/Test-JavaScript.ps1
@@ -1,5 +1,5 @@
 $Project = "$($env:APPVEYOR_BUILD_FOLDER)\Nancy.ViewEngines.React.UnitTests"
-$Stream = cmd /c "$($Project)\node_modules\.bin\mocha" --compilers js:babel/register -R json "$($Project)/*Tests/**/*.js"
+$Stream = cmd /c "cd $($Project) && .\.bin\npm test --silent -- -R json"
 if ($LastExitCode -ne 0) {
     Write-Host "Fail the build because mocha command exits with $LastExitCode"
     $host.SetShouldExit($LastExitCode)

--- a/Nancy.ViewEngines.React/Nancy.ViewEngines.React.csproj
+++ b/Nancy.ViewEngines.React/Nancy.ViewEngines.React.csproj
@@ -116,9 +116,9 @@
   </Target>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="BeforeBuild">
-    <Exec Command=".\Nancy.ViewEngines.React\.bin\npm --unicode=false install" WorkingDirectory="$(SolutionDir)" />
     <Exec Command=".\.bin\npm --unicode=false install" WorkingDirectory="$(MSBuildProjectPath)" />
-    <Exec Command=".\node_modules\.bin\eslint --ext .js,.jsx &quot;$(ProjectDir)\tools&quot;" WorkingDirectory="$(SolutionDir)" />
+    <Exec Command=".\Nancy.ViewEngines.React\.bin\npm --unicode=false install" WorkingDirectory="$(SolutionDir)" />
+    <Exec Command=".\Nancy.ViewEngines.React\.bin\npm run lint" WorkingDirectory="$(SolutionDir)" />
     <Exec Command=".\tools\7za a -t7z -bd -mx9 -y .\node_modules.7z .\node_modules" WorkingDirectory="$(MSBuildProjectPath)" />
   </Target>
   <Target Name="AfterBuild">

--- a/Nancy.ViewEngines.React/Nancy.ViewEngines.React.csproj
+++ b/Nancy.ViewEngines.React/Nancy.ViewEngines.React.csproj
@@ -98,6 +98,7 @@
     <None Include="tools\commands\webpack.js" />
     <None Include="tools\install.ps1" />
     <None Include="tools\node.cmd" />
+    <None Include="tools\npm.cmd" />
     <None Include="tools\uninstall.ps1" />
   </ItemGroup>
   <ItemGroup>

--- a/Nancy.ViewEngines.React/Nancy.ViewEngines.React.nuspec
+++ b/Nancy.ViewEngines.React/Nancy.ViewEngines.React.nuspec
@@ -16,6 +16,7 @@
   <files>
     <file src="targets\**\*" target="build" />
     <file src="tools\**\*" target="tools" />
+    <file src="package.json" target="package.json" />
     <file src="node_modules.7z" target="node_modules.7z" />
   </files>
 </package>

--- a/Nancy.ViewEngines.React/package.json
+++ b/Nancy.ViewEngines.React/package.json
@@ -12,5 +12,8 @@
     "xml2js": "^0.4.12",
     "xmldom": "^0.1.19",
     "xpath": "0.0.23"
+  },
+  "scripts": {
+    "build": "node ./tools/build"
   }
 }

--- a/Nancy.ViewEngines.React/targets/Nancy.ViewEngines.React.targets
+++ b/Nancy.ViewEngines.React/targets/Nancy.ViewEngines.React.targets
@@ -10,18 +10,19 @@
     <!--
       The whitespaces wrapping the path variables are critical.
       They avoid the tailing character is back-slash to escape the quote sign.
-      They will be trim off when parse from gulp.
+      They will be trim off during build.
     -->
     <Execute>
       <![CDATA[
-      .\node .\build " $(MSBuildProjectFullPath) " " $(OutputPath) " "$(Configuration)"
+      set PATH=.\tools;%PATH%
+      .\tools\npm run build -- " $(MSBuildProjectFullPath) " " $(OutputPath) " " $(Configuration) "
       ]]>
     </Execute>
   </PropertyGroup>
   <Target Name="RestoreReactViewEnginePackages">
     <Message Text="Building React view engine scripts..." />
     <Exec Command=".\.bin\npm --unicode=false install" WorkingDirectory="$(MSBuildProjectPath)" />
-    <Exec Command="$(Execute)" WorkingDirectory="$(MSBuildThisFileDirectory)..\tools" />
+    <Exec Command="$(Execute)" WorkingDirectory="$(MSBuildThisFileDirectory).." />
     <Message Text="React view engine scripts is built!" />
   </Target>
 </Project>

--- a/Nancy.ViewEngines.React/tools/build.js
+++ b/Nancy.ViewEngines.React/tools/build.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 
+const path = require('path');
 const options = require('./commands/options');
 const clean = require('./commands/clean');
 const buildEntry = require('./commands/entry');
@@ -10,8 +11,8 @@ function trim(str) {
 }
 
 const env = {
-  projectFile: trim(process.argv[2]),
-  outputPath: trim(process.argv[3]),
+  projectFile: trim(process.argv[2]) || path.resolve(__dirname, '../package.json'),
+  outputPath: trim(process.argv[3]) || 'bin',
   configuration: trim(process.argv[4]),
 };
 

--- a/Nancy.ViewEngines.React/tools/commands/options.js
+++ b/Nancy.ViewEngines.React/tools/commands/options.js
@@ -64,7 +64,7 @@ function parseConfig(config) {
 function buildOptions(config, env, projectFile, projectPath) {
   const debug = env.configuration !== 'Release';
   const entryFileName = 'entry.map';
-  const outputPath = (env.outputPath || 'bin').trim();
+  const outputPath = env.outputPath;
   const clientPath = path.resolve(projectPath, outputPath, config.script.dir);
   return {
     debug,
@@ -82,7 +82,7 @@ function buildOptions(config, env, projectFile, projectPath) {
 }
 
 function parseOptions(env) {
-  const projectFile = (env.projectFile || __filename).trim();
+  const projectFile = env.projectFile;
   const projectPath = path.dirname(projectFile);
 
   return Promise.resolve()

--- a/Nancy.ViewEngines.React/tools/commands/webpack.js
+++ b/Nancy.ViewEngines.React/tools/commands/webpack.js
@@ -73,11 +73,20 @@ function compile(options) {
   });
 }
 
+function outputError(error) {
+  console.log(error.toString());
+
+  if (error.details) {
+    console.log(error.details);
+  }
+}
+
 function build(options) {
   return Promise.resolve()
     .then(() => console.log('[Start] Webpack.'))
     .then(() => compile(options))
     .then(stats => console.log(stats))
+    .catch(outputError)
     .then(() => console.log('[End] Webpack.'))
     .then(() => options);
 }

--- a/Nancy.ViewEngines.React/tools/node.cmd
+++ b/Nancy.ViewEngines.React/tools/node.cmd
@@ -1,13 +1,15 @@
 @echo off
 for /f "delims=" %%A in ('dir "%~dp0..\..\node.js.*" /b') do set "nodePath=%%A"
 
-if not "%nodePath%" == "" (
-  "%~dp0..\..\%nodePath%\node" %*
-  goto exit
+REM This works for shipped NuGet package structure.
+if exist "%~dp0..\..\%nodePath%\node.exe" (
+  "%~dp0..\..\%nodePath%\node.exe" %*
+  exit /b %errorlevel%
 )
 
-REM for example project which reference target file directly
+REM This works for development structure.
 for /f "delims=" %%A in ('dir "%~dp0..\..\packages\node.js.*" /b') do set "nodePath=%%A"
-"%~dp0..\..\packages\%nodePath%\node" %*
-
-:exit
+if exist "%~dp0..\..\packages\%nodePath%\node.exe" (
+  "%~dp0..\..\packages\%nodePath%\node.exe" %*
+  exit /b %errorlevel%
+)

--- a/Nancy.ViewEngines.React/tools/npm.cmd
+++ b/Nancy.ViewEngines.React/tools/npm.cmd
@@ -1,0 +1,15 @@
+@echo off
+for /f "delims=" %%A in ('dir "%~dp0..\..\Npm.*" /b') do set "npmPath=%%A"
+
+REM This works for shipped NuGet package structure.
+if exist "%~dp0..\..\%npmPath%\node_modules\npm\bin\npm-cli.js" (
+  "%~dp0node" "%~dp0..\..\%npmPath%\node_modules\npm\bin\npm-cli.js" %*
+  exit /b %errorlevel%
+)
+
+REM This works for development structure.
+for /f "delims=" %%A in ('dir "%~dp0..\..\packages\Npm.*" /b') do set "npmPath=%%A"
+if exist "%~dp0..\..\packages\%npmPath%\node_modules\npm\bin\npm-cli.js" (
+  "%~dp0node" "%~dp0..\..\packages\%npmPath%\node_modules\npm\bin\npm-cli.js" %*
+  exit /b %errorlevel%
+)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ All settings are optional. Pre-defined settings work well in most cases. But you
 
   Please reference [ReactConfiguration.xsd](https://github.com/lijunle/Nancy.ViewEngines.React/blob/master/Nancy.ViewEngines.React/ReactConfiguration.xsd) for available settings and their documentations, reference [ConfigurationFixtures](https://github.com/lijunle/Nancy.ViewEngines.React/tree/master/Nancy.ViewEngines.React.UnitTests/ConfigurationFixtures) folder for examples.
 
-  ```
+  ```xml
   <?xml version="1.0" encoding="utf-8"?>
   <configuration>
     <configSections>
@@ -65,7 +65,7 @@ The react view engine natively provide anti-forgenry token to prevent cross-site
 
 In your view component, import `anti-forgery-token` as a React component. Then render this component in your form component.
 
-Please reference [AntiForgery.jsx](https://github.com/lijunle/Nancy.ViewEngines.React/blob/master/Nancy.ViewEngines.React.Example/Views/AntiFogery.jsx) for an example.
+Please reference [AntiForgery.jsx](https://github.com/lijunle/Nancy.ViewEngines.React/blob/master/Nancy.ViewEngines.React.Example/Views/AntiForgery.jsx) for an example.
 
 # Debug build
 


### PR DESCRIPTION
- Fix the test break in UnitTest project. It should detect the test is breaking now.
- Fix a typo in README. Right reference to AntiForgery.js file.
- Extract the commands to `package.json` as scripts section, which can be consumed by CLI.
- In CSPROJ or build target file, reference run NPM scripts.
- Run full ESLint in Nancy.ViewEngines.React project, other project no needs to run linter any more.
